### PR TITLE
Add license for release artifacts + trademarks; update README licensing

### DIFF
--- a/LICENSE-ARTIFACTS.txt
+++ b/LICENSE-ARTIFACTS.txt
@@ -26,3 +26,15 @@ NO WARRANTY
 
 CONTACT
 - For licensing or partnership inquiries, request permission from the copyright holder.
+
+# Trademarks
+
+“prohormonePro” and associated logos are trademarks of their owner.
+
+You may reference the name in a descriptive, factual manner (e.g., “verified by prohormonePro”)
+but you may not:
+- Use the marks or logo to imply endorsement, sponsorship, or affiliation.
+- Use the marks in product names, domain names, app names, or advertising.
+- Alter or combine the marks with your own branding.
+
+No trademark license is granted by this repository. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Cross-check the key here and on the trust page: [https://trust.prohormonepro.com
 
 ---
 
-## License
+## Licensing
 
-MIT — see [`LICENSE`](./LICENSE).
+- **Code (site + verify scripts):** MIT — see [`LICENSE`](./LICENSE)
+- **Release artifacts (ZIP/TAR.GZ contents):** All rights reserved — see [`LICENSE-ARTIFACTS.txt`](./LICENSE-ARTIFACTS.txt)
+- **Brand/marks:** see [`TRADEMARKS.md`](./TRADEMARKS.md)

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,11 @@
+# Trademarks
+
+“prohormonePro” and associated logos are trademarks of their owner.
+
+You may reference the name in a descriptive, factual manner (e.g., “verified by prohormonePro”),
+but you may not:
+- Use the marks or logo to imply endorsement, sponsorship, or affiliation.
+- Use the marks in product names, domain names, app names, or advertising.
+- Alter or combine the marks with your own branding.
+
+No trademark license is granted by this repository. All rights reserved.


### PR DESCRIPTION
**What**
- Add `LICENSE-ARTIFACTS.txt` (All rights reserved for release artifacts)
- Add `TRADEMARKS.md` (brand/marks usage)
- Update `README.md` with a clear Licensing section

**Why**
- Keep verification scripts/site open under MIT
- Lock down redistribution/commercial use of *artifacts* (ZIP/TAR.GZ contents)
- Clarify that brand/marks are not granted by MIT

**Notes**
- Docs-only change; no code behavior.
- Pages will rebuild; content is markdown-only.

**Next release**
- Ensure `LICENSE-ARTIFACTS.txt` is *also included inside* `Public_release/` before zipping.